### PR TITLE
Make allocator threadsafe and add a job chaining reservation API.

### DIFF
--- a/IBEngine/IBAllocator.h
+++ b/IBEngine/IBAllocator.h
@@ -38,7 +38,7 @@ namespace IB
     T *allocate(TArgs &&... args)
     {
         void *memory = memoryAllocate(sizeof(T), alignof(T));
-        return new (memory) T(std::forward<TArgs>(args)...);
+        return new (memory) T{ std::forward<TArgs>(args)... };
     }
 
     template <typename T>

--- a/IBEngine/IBJobs.h
+++ b/IBEngine/IBJobs.h
@@ -16,13 +16,22 @@ Simply give it a lambda (or a function + data pointer) and expect it to run at s
 Assure that the data that you provide to the lambda will survive for the lifetime of the job
 and is thread-safe.
 
-TODO: Add some information about chaining lambdas when that API is added.
+Job chaining should be relatively simple. You can simply call "continueJob" alongside the source
+job you should be waiting on. Once you wait on the job, it should just work.
+
+TODO: explain job reservation flow and sleep/complete
 */
 
 namespace IB
 {
+    enum class JobResult
+    {
+        Complete,
+        Sleep
+    };
+
     constexpr size_t MaxJobDataSize = 64;
-    using JobFunc = void(void *data);
+    using JobFunc = JobResult(void *data);
 
     struct JobDesc
     {
@@ -37,8 +46,48 @@ namespace IB
 
     IB_API void initJobSystem();
     IB_API void killJobSystem();
+
     IB_API JobHandle launchJob(JobDesc desc);
-    IB_API JobHandle continueJob(JobDesc desc, JobHandle sourceJob);
+    IB_API JobHandle continueJob(JobDesc desc, JobHandle* dependencies, uint32_t dependencyCount);
+
+    // This continuation API allows us to put a job to sleep
+    // but to execute it again in the future.
+    // This allows us to wait on a job handle but have it execute multiple times
+    // before signaling the waiting jobs.
+    // When marking a job as complete, 2 things happen
+    // - The waiting jobs are signaled
+    // - The job generation is advanced
+    // This makes our current job invalid.
+    //
+    // There are times however, where you might want to return from the job
+    // and not signal the waiting jobs
+    // then you might want to re-enter the job
+    // and finally signal the waiting jobs
+    // This can happen if I want to launch some jobs from my current job
+    // then wait on those jobs
+    // and finally return to the parent job to do some finalization work
+    //
+    // Putting a job to sleep will not signal the waiting jobs and will not advance the generation
+    // meaning that you can wait on a sleeping job
+    //
+    // Typically in this context, you'll want to reference the job's handle from within the job
+    // using the launchJob or continueJob API and storing the return type is erroneous.
+    // Since the job might trigger and complete before the value is stored
+    // As a result, you want to reserve the job to get the handle before launching the job.
+    // An example of this is:
+    // JobHandle = reserveJob(JobThatReferencesJobHandle)
+    // launchJob(jobHandle)
+    // Whereas
+    // JobHandle = launchJob(JobThatReferencesJobHandle)
+    // might introduce subtle bugs.
+
+    // Reserve a job for later execution
+    IB_API JobHandle reserveJob(JobDesc desc);
+
+    IB_API void launchJob(JobHandle handle);
+    IB_API void continueJob(JobHandle handle, JobHandle* dependencies, uint32_t dependencyCount);
+
+    // Utility API
 
     template <typename T>
     JobHandle launchJob(const T &functor)
@@ -46,29 +95,45 @@ namespace IB
         static_assert(sizeof(T) <= MaxJobDataSize, "Functor is too large for job. Consider allocating it on the heap.");
 
         JobDesc desc;
-        desc.Func = [](void *functor) { (*reinterpret_cast<T *>(functor))(); };
+        desc.Func = [](void *functor) { return (*reinterpret_cast<T *>(functor))(); };
         memcpy(desc.JobData, &functor, sizeof(T));
         return launchJob(desc);
     }
 
     inline JobHandle launchJob(JobFunc *job, void *data)
     {
-        return launchJob([job, data]() { job(data); });
+        return launchJob([job, data]() { return job(data); });
     }
 
     template <typename T>
-    JobHandle continueJob(const T &functor, JobHandle sourceJob)
+    JobHandle continueJob(const T &functor, JobHandle* dependencies, uint32_t dependencyCount)
     {
         static_assert(sizeof(T) <= MaxJobDataSize, "Functor is too large for job. Consider allocating it on the heap.");
 
         JobDesc desc;
-        desc.Func = [](void *functor) { (*reinterpret_cast<T *>(functor))(); };
+        desc.Func = [](void *functor) { return (*reinterpret_cast<T *>(functor))(); };
         memcpy(desc.JobData, &functor, sizeof(T));
-        return continueJob(desc, sourceJob);
+        return continueJob(desc, dependencies, dependencyCount);
     }
 
-    inline JobHandle continueJob(JobFunc *job, void *data, JobHandle sourceJob)
+    inline JobHandle continueJob(JobFunc *job, void *data, JobHandle* dependencies, uint32_t dependencyCount)
     {
-        return continueJob([job, data]() { job(data); }, sourceJob);
+        return continueJob([job, data]() { return job(data); }, dependencies, dependencyCount);
+    }
+
+    template <typename T>
+    JobHandle reserveJob(const T &functor)
+    {
+        static_assert(sizeof(T) <= MaxJobDataSize, "Functor is too large for job. Consider allocating it on the heap.");
+
+        JobDesc desc;
+        desc.Func = [](void *functor) { return (*reinterpret_cast<T *>(functor))(); };
+        memcpy(desc.JobData, &functor, sizeof(T));
+        return reserveJob(desc);
+    }
+
+    inline JobHandle reserveJob(JobFunc *job, void *data)
+    {
+        return reserveJob([job, data]() { return job(data); });
     }
 } // namespace IB

--- a/IBEngine/IBSerialization.h
+++ b/IBEngine/IBSerialization.h
@@ -30,6 +30,7 @@ namespace IB
 
         struct IB_API MemoryStream
         {
+            MemoryStream() = default;
             MemoryStream(uint8_t *memory) : Memory(memory) {}
             uint8_t *Memory = nullptr;
         };

--- a/IBEngine/Platform/IBPlatform.h
+++ b/IBEngine/Platform/IBPlatform.h
@@ -142,30 +142,21 @@ namespace IB
     IB_API void freeMemoryPages(void *pages, uint32_t pageCount);
 
     // When requesting large blocks of memory, consider using a memory mapping
-    IB_API void *mapLargeMemoryBlock(size_t size);
-    IB_API void unmapLargeMemoryBlock(void *memory);
+    IB_API void *mapLargeMemoryBlock(size_t size); // Threadsafe
+    IB_API void unmapLargeMemoryBlock(void *memory); // Threadsafe as long as you don't unmap the same memory block.
 
     // Atomic API
-    struct AtomicU32
-    {
-        uint32_t volatile Value;
-    };
 
-    struct AtomicU64
-    {
-        uint64_t volatile Value;
-    };
-
-    struct AtomicPtr
-    {
-        void *volatile Value;
-    };
-
-    IB_API uint32_t atomicIncrement(AtomicU32 *atomic);
-    IB_API uint32_t atomicDecrement(AtomicU32 *atomic);
-    IB_API uint32_t atomicCompareExchange(AtomicU32 *atomic, uint32_t compare, uint32_t exchange);
-    IB_API uint64_t atomicCompareExchange(AtomicU64 *atomic, uint64_t compare, uint64_t exchange);
-    IB_API void *atomicCompareExchange(AtomicPtr *atomic, void *compare, void *exchange);
+    IB_API uint32_t atomicIncrement(uint32_t volatile *atomic);
+    IB_API uint32_t atomicDecrement(uint32_t volatile *atomic);
+    IB_API uint32_t atomicCompareExchange(uint32_t volatile *atomic, uint32_t compare, uint32_t exchange);
+    IB_API uint64_t atomicCompareExchange(uint64_t volatile *atomic, uint64_t compare, uint64_t exchange);
+    IB_API void *atomicCompareExchange(void *volatile *atomic, void *compare, void *exchange);
+    inline uint32_t atomicIncrement(uint32_t *atomic) { return atomicIncrement(static_cast<uint32_t volatile *>(atomic)); }
+    inline uint32_t atomicDecrement(uint32_t *atomic) { return atomicDecrement(static_cast<uint32_t volatile *>(atomic)); }
+    inline uint32_t atomicCompareExchange(uint32_t *atomic, uint32_t compare, uint32_t exchange) { return atomicCompareExchange(static_cast<uint32_t volatile *>(atomic), compare, exchange); }
+    inline uint64_t atomicCompareExchange(uint64_t *atomic, uint64_t compare, uint64_t exchange) { return atomicCompareExchange(static_cast<uint64_t volatile *>(atomic), compare, exchange); }
+    inline void *atomicCompareExchange(void **atomic, void *compare, void *exchange) { return atomicCompareExchange(static_cast<void *volatile *>(atomic), compare, exchange); }
 
     // Threading API
     struct ThreadHandle
@@ -211,15 +202,15 @@ namespace IB
         };
     };
 
-    IB_API File openFile(char const *filepath, uint32_t options);
-    IB_API void closeFile(File file);
-    IB_API void *mapFile(File file);
-    IB_API void unmapFile(File file);
+    IB_API File openFile(char const *filepath, uint32_t options); // Threadsafe
+    IB_API void closeFile(File file); // Threadsafe
+    IB_API void *mapFile(File file); // Threadsafe
+    IB_API void unmapFile(File file); // Threadsafe as long as you don't unmap the same file in another thread
     IB_API void writeToFile(File file, void *data, size_t size);
     IB_API void appendToFile(File file, void *data, size_t size);
     IB_API size_t fileSize(File file);
 
     // File system
-    IB_API bool isDirectory(char const* path);
-    IB_API void setWorkingDirectory(char const* path);
+    IB_API bool isDirectory(char const *path);
+    IB_API void setWorkingDirectory(char const *path);
 } // namespace IB

--- a/Samples/SampleThreading/SampleThreading.cpp
+++ b/Samples/SampleThreading/SampleThreading.cpp
@@ -1,10 +1,12 @@
 
 #include <IBEngine/IBJobs.h>
 #include <IBEngine/Platform/IBPlatform.h>
+#include <IBEngine/IBAllocator.h>
+#include <IBEngine/IBLogging.h>
 #include <stdio.h>
 #include <Windows.h>
 
-IB::AtomicU32 Counter = { 0 };
+uint32_t volatile Counter = 0;
 int main()
 {
     IB::initJobSystem();
@@ -16,14 +18,15 @@ int main()
         IB::launchJob([]()
         {
             IB::atomicIncrement(&Counter);
-            printf("%u ", Counter.Value);
+            printf("%u ", Counter);
+            return IB::JobResult::Complete;
         });
     }
 
-    while (Counter.Value != iterations) {}
+    while (Counter != iterations) {}
 
     // Spawn job from job
-    Counter.Value = 0;
+    Counter = 0;
     for (uint32_t i = 0; i < iterations / 10; i++)
     {
         IB::launchJob([]()
@@ -33,42 +36,161 @@ int main()
                 IB::launchJob([i]()
                 {
                     IB::atomicIncrement(&Counter);
-                    printf("%u: %u ", i, Counter.Value);
+                    printf("%u: %u ", i, Counter);
+                    return IB::JobResult::Complete;
                 });
             }
+            return IB::JobResult::Complete;
         });
     }
 
-    while (Counter.Value != iterations) {}
+    while (Counter != iterations) {}
 
     for (uint32_t i = 0; i < 10; i++)
     {
         IB::JobHandle sleepJob = IB::launchJob([]()
         {
             Sleep(100);
+            return IB::JobResult::Complete;
         });
         IB::JobHandle continueJob1 = IB::continueJob([]()
         {
             Sleep(10);
-        }, sleepJob);
+            return IB::JobResult::Complete;
+        }, &sleepJob, 1);
         IB::JobHandle continueJob2 = IB::continueJob([]()
         {
             Sleep(10);
-        }, sleepJob);
+            return IB::JobResult::Complete;
+        }, &sleepJob, 1);
 
-        Counter.Value = 0;
+        Counter = 0;
         IB::continueJob([]()
         {
             IB::atomicIncrement(&Counter);
-        }, continueJob1);
+            return IB::JobResult::Complete;
+        }, &continueJob1, 1);
 
         IB::continueJob([]()
         {
             IB::atomicIncrement(&Counter);
-        }, continueJob2);
+            return IB::JobResult::Complete;
+        }, &continueJob2, 1);
 
-        while (Counter.Value != 2) {}
+        while (Counter != 2) {}
     }
+
+    for (uint32_t i = 0; i < 10; i++)
+    {
+        IB::JobHandle sleepJob = IB::launchJob([]()
+        {
+            Sleep(100);
+            return IB::JobResult::Complete;
+        });
+
+        IB::JobHandle continueJobs[10];
+        for (uint32_t j = 0; j < 10; j++)
+        {
+            continueJobs[j] = IB::continueJob([]()
+            {
+                Sleep(10);
+                return IB::JobResult::Complete;
+            }, &sleepJob, 1);
+        }
+
+        Counter = 0;
+        IB::continueJob([]()
+        {
+            IB::atomicIncrement(&Counter);
+            return IB::JobResult::Complete;
+        }, continueJobs, 10);
+
+        while (Counter != 1) {}
+    }
+
+    IB::JobHandle myHandle;
+    myHandle = IB::reserveJob([&myHandle]()
+    {
+        if (Counter == 0)
+        {
+            IB::JobHandle childJob = IB::launchJob([]()
+            {
+                Sleep(10);
+                return IB::JobResult::Complete;
+            });
+
+            IB::continueJob(myHandle, &childJob, 1);
+            IB::atomicIncrement(&Counter);
+            return IB::JobResult::Sleep;
+        }
+        else
+        {
+            IB::atomicIncrement(&Counter);
+            return IB::JobResult::Complete;
+        }
+    });
+
+    Counter = 0;
+    IB::launchJob(myHandle);
+
+    while (Counter != 2) {}
+
+    // Small memory allocations
+    Counter = 0;
+    float volatile* initialFloat = IB::allocate<float>(2.0f);
+    for (uint32_t i = 0; i < iterations; i++)
+    {
+        IB::launchJob([]()
+        {
+            IB::atomicIncrement(&Counter);
+
+            // Try to hammer the allocator as much as possible.
+            float* value = IB::allocate<float>(1.0f);
+            printf("%f ", *value);
+            IB::deallocate(value);
+
+            return IB::JobResult::Complete;
+        });
+    }
+    while (Counter != iterations) {}
+    IB_ASSERT(*initialFloat == 2.0f, "Our float changed value!");
+    IB::deallocate((float*)initialFloat);
+
+    // Medium memory allocations
+    Counter = 0;
+    for (uint32_t i = 0; i < iterations; i++)
+    {
+        IB::launchJob([]()
+        {
+            IB::atomicIncrement(&Counter);
+
+            // Try to hammer the allocator as much as possible.
+            void* value = IB::memoryAllocate(4096, 4);
+            printf("allocation ");
+            IB::memoryFree(value);
+
+            return IB::JobResult::Complete;
+        });
+    }
+    while (Counter != iterations) {}
+
+    // large memory allocations
+    Counter = 0;
+    for (uint32_t i = 0; i < 20; i++)
+    {
+        IB::launchJob([]()
+        {
+            IB::atomicIncrement(&Counter);
+
+            // Try to hammer the allocator as much as possible.
+            void* value = IB::memoryAllocate(1024 * 1024 * 1024, 1024);
+            printf("LARGE ");
+            IB::memoryFree(value);
+
+            return IB::JobResult::Complete;
+        });
+    }
+    while (Counter != 10) {}
 
     IB::killJobSystem();
 }


### PR DESCRIPTION
Fixes #21 

Fixed a bug I introduced in a previous CL due to lack of testing...
Added a GameObject sample for implementing the game object model.
Added uint64_t atomics.
Added some utils to the serialization system.

Fix error with job system wait not having the correct number of elements.

Added a job reservation API to the job system.
Added an example asset loader that correctly waits on dependencies.

Made small allocations thread safe.
Removed AtomicU32/AtomicPtr types.

Made medium memory allocations threadsafe by simply locking the buddy chunks.

Made large memory allocations threadsafe!

Added job chaining to the job system.
Fixed a bug I introduced in a previous CL due to lack of testing...
Added a GameObject sample for implementing the game object model.
Added uint64_t atomics.
Added some utils to the serialization system.

Fix error with job system wait not having the correct number of elements.

Added job chaining to the job system.
Fixed a bug I introduced in a previous CL due to lack of testing...
Added a GameObject sample for implementing the game object model.
Added uint64_t atomics.
Added some utils to the serialization system.

Fix error with job system wait not having the correct number of elements.

Added a job reservation API to the job system.
Added an example asset loader that correctly waits on dependencies.

Made small allocations thread safe.
Removed AtomicU32/AtomicPtr types.

Made medium memory allocations threadsafe by simply locking the buddy chunks.

Made large memory allocations threadsafe!